### PR TITLE
Redis cache driver

### DIFF
--- a/xtraplatform-base/src/main/java/de/ii/xtraplatform/base/domain/RedisConfiguration.java
+++ b/xtraplatform-base/src/main/java/de/ii/xtraplatform/base/domain/RedisConfiguration.java
@@ -14,6 +14,7 @@ import de.ii.xtraplatform.docs.DocStep.Step;
 import de.ii.xtraplatform.docs.DocTable;
 import de.ii.xtraplatform.docs.DocTable.ColumnSet;
 import java.util.List;
+import java.util.Optional;
 import org.immutables.value.Value;
 
 /**
@@ -40,7 +41,6 @@ import org.immutables.value.Value;
 @Value.Immutable
 @Value.Modifiable
 @JsonDeserialize(as = ModifiableRedisConfiguration.class)
-@FunctionalInterface
 public interface RedisConfiguration {
 
   /**
@@ -51,4 +51,16 @@ public interface RedisConfiguration {
    * @default []
    */
   List<String> getNodes();
+
+  /**
+   * @langEn Identifies a group of instances that share state (e.g. cache entries) through Redis.
+   *     Only instances with the same configuration should use the same value. If not set, falls
+   *     back to the instance name.
+   * @langDe Identifiziert eine Gruppe von Instanzen, die sich über Redis Zustand (z.B.
+   *     Cache-Einträge) teilen. Nur Instanzen mit der gleichen Konfiguration sollten den gleichen
+   *     Wert verwenden. Falls nicht gesetzt, wird der Instanzname verwendet.
+   * @since v4.8
+   * @default optional
+   */
+  Optional<String> getCluster();
 }

--- a/xtraplatform-cache/src/main/java/de/ii/xtraplatform/cache/app/CacheImpl.java
+++ b/xtraplatform-cache/src/main/java/de/ii/xtraplatform/cache/app/CacheImpl.java
@@ -9,6 +9,7 @@ package de.ii.xtraplatform.cache.app;
 
 import com.github.azahnen.dagger.annotations.AutoBind;
 import dagger.Lazy;
+import de.ii.xtraplatform.base.domain.AppContext;
 import de.ii.xtraplatform.base.domain.AppLifeCycle;
 import de.ii.xtraplatform.cache.domain.Cache;
 import de.ii.xtraplatform.cache.domain.CacheDriver;
@@ -28,17 +29,18 @@ public class CacheImpl implements Cache, AppLifeCycle {
   private static final Logger LOGGER = LoggerFactory.getLogger(CacheImpl.class);
 
   private final Lazy<Set<CacheDriver>> drivers;
+  private final String type;
 
   private CacheDriver driver;
 
   @Inject
-  public CacheImpl(Lazy<Set<CacheDriver>> drivers) {
+  public CacheImpl(Lazy<Set<CacheDriver>> drivers, AppContext appContext) {
     this.drivers = drivers;
+    this.type = appContext.getConfiguration().getRedis().getNodes().isEmpty() ? "FS" : "REDIS";
   }
 
   @Override
   public CompletionStage<Void> onStart(boolean isStartupAsync) {
-    String type = "FS";
     this.driver =
         drivers.get().stream()
             .filter(cacheDriver -> Objects.equals(cacheDriver.getType(), type))

--- a/xtraplatform-redis/build.gradle
+++ b/xtraplatform-redis/build.gradle
@@ -7,6 +7,7 @@ descriptionDe = 'Redis Job Queue und Cache.'
 dependencies {
     provided project(':xtraplatform-cache')
     provided project(':xtraplatform-jobs')
+    provided project(':xtraplatform-values')
 
     embedded(libs.jedis) {
         exclude module: 'slf4j-api'

--- a/xtraplatform-redis/src/main/java/de/ii/xtraplatform/redis/app/CacheDriverRedis.java
+++ b/xtraplatform-redis/src/main/java/de/ii/xtraplatform/redis/app/CacheDriverRedis.java
@@ -8,6 +8,7 @@
 package de.ii.xtraplatform.redis.app;
 
 import com.github.azahnen.dagger.annotations.AutoBind;
+import de.ii.xtraplatform.base.domain.AppContext;
 import de.ii.xtraplatform.base.domain.Jackson;
 import de.ii.xtraplatform.cache.domain.CacheDriver;
 import de.ii.xtraplatform.redis.domain.Redis;
@@ -54,6 +55,11 @@ import redis.clients.jedis.commands.JedisBinaryCommands;
  * is available yet. Every method here treats that the same as a cache miss/no-op rather than
  * throwing, instead of assuming binary() is always ready like CacheDriverFs's filesystem access
  * always is.
+ *
+ * <p>Keys are scoped by a cluster id (RedisConfiguration.getCluster(), falling back to
+ * AppContext.getInstanceName() if not set), so only instances sharing the same configuration - and
+ * thus the same cluster id - share cache entries; instances pointed at the same Redis but with a
+ * different/absent cluster id get their own separate key namespace.
  */
 @Singleton
 @AutoBind
@@ -66,11 +72,18 @@ public class CacheDriverRedis implements CacheDriver {
 
   private final Redis redis;
   private final ValueEncoding<Object> valueEncoding;
+  private final String clusterId;
 
   @Inject
-  public CacheDriverRedis(Redis redis, Jackson jackson) {
+  public CacheDriverRedis(Redis redis, Jackson jackson, AppContext appContext) {
     this.redis = redis;
     this.valueEncoding = new ValueEncodingJackson<>(jackson, null, false);
+    this.clusterId =
+        appContext
+            .getConfiguration()
+            .getRedis()
+            .getCluster()
+            .orElseGet(appContext::getInstanceName);
   }
 
   @Override
@@ -205,7 +218,7 @@ public class CacheDriverRedis implements CacheDriver {
   }
 
   private byte[] redisKey(String key) {
-    return (KEY_PREFIX + key).getBytes(StandardCharsets.UTF_8);
+    return (KEY_PREFIX + clusterId + ":" + key).getBytes(StandardCharsets.UTF_8);
   }
 
   private byte[] validatorField(String validator) {

--- a/xtraplatform-redis/src/main/java/de/ii/xtraplatform/redis/app/CacheDriverRedis.java
+++ b/xtraplatform-redis/src/main/java/de/ii/xtraplatform/redis/app/CacheDriverRedis.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2026 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.xtraplatform.redis.app;
+
+import com.github.azahnen.dagger.annotations.AutoBind;
+import de.ii.xtraplatform.base.domain.Jackson;
+import de.ii.xtraplatform.cache.domain.CacheDriver;
+import de.ii.xtraplatform.redis.domain.Redis;
+import de.ii.xtraplatform.values.api.ValueEncodingJackson;
+import de.ii.xtraplatform.values.domain.ValueEncoding;
+import de.ii.xtraplatform.values.domain.ValueEncoding.FORMAT;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Objects;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import redis.clients.jedis.commands.JedisCommands;
+
+/**
+ * Redis-backed CacheDriver, sharing the same Redis connection as JobQueueBackendRedis (s. Redis,
+ * injected). Mirrors CacheDriverFs's shape: one Hash per key, the "validator" argument is the Hash
+ * field name (CONTENT for the plain 2-arg has/get/put), so a single key can hold several
+ * independently addressable entries under different validators, same as CacheDriverFs's
+ * one-file-per-validator directory layout.
+ *
+ * <p>Two deliberate deviations from CacheDriverFs, neither changes observable behavior:
+ *
+ * <ul>
+ *   <li>No key hashing - CacheDriverFs hashes the key into a filesystem-safe directory name; Redis
+ *       keys have no such restriction, so the key is used as-is (only prefixed), which also keeps
+ *       it readable in redis-cli.
+ *   <li>No manual TTL bookkeeping/expiry check - CacheDriverFs stores an expiry timestamp itself
+ *       and checks it on every access. expire/persist on the whole Hash key does the same job
+ *       natively; once it elapses, Redis removes the key on its own, so has/get simply observe it
+ *       as absent. TTL applies to the whole key (all validators together), exactly like
+ *       CacheDriverFs's single ttl file per key directory, not per validator.
+ * </ul>
+ *
+ * <p>Values are serialized identically to CacheDriverFs (String passthrough as UTF-8, everything
+ * else via Jackson SMILE) and then Base64-encoded, since the Jedis command surface used here
+ * (JedisCommands, via Redis.cmd()) is String-only, not binary-safe.
+ *
+ * <p>Redis.cmd() can legitimately return null - RedisImpl only actually connects lazily from its
+ * periodic Volatile2 health check (s. RedisImpl's check()/connect()), not synchronously at startup,
+ * so there's a window (and, if the connection is ever lost, an ongoing possibility) where no client
+ * is available yet. Every method here treats that the same as a cache miss/no-op rather than
+ * throwing, instead of assuming cmd() is always ready like CacheDriverFs's filesystem access always
+ * is.
+ */
+@Singleton
+@AutoBind
+public class CacheDriverRedis implements CacheDriver {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(CacheDriverRedis.class);
+
+  private static final String KEY_PREFIX = "xtraplatform:cache:";
+  private static final String CONTENT = "content";
+
+  private final Redis redis;
+  private final ValueEncoding<Object> valueEncoding;
+
+  @Inject
+  public CacheDriverRedis(Redis redis, Jackson jackson) {
+    this.redis = redis;
+    this.valueEncoding = new ValueEncodingJackson<>(jackson, null, false);
+  }
+
+  @Override
+  public String getType() {
+    return "REDIS";
+  }
+
+  @Override
+  public boolean init() {
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Started {} cache", getType());
+    }
+    return true;
+  }
+
+  @Override
+  public boolean has(String key) {
+    return has(key, CONTENT);
+  }
+
+  @Override
+  public boolean has(String key, String validator) {
+    JedisCommands cmd = cmd();
+    if (Objects.isNull(cmd)) {
+      return false;
+    }
+
+    boolean exists = cmd.hexists(redisKey(key), validator);
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Cache has({}, {}) -> {}", key, validator, exists);
+    }
+    return exists;
+  }
+
+  @Override
+  public <T> Optional<T> get(String key, Class<T> clazz) {
+    return get(key, CONTENT, clazz);
+  }
+
+  @Override
+  public <T> Optional<T> get(String key, String validator, Class<T> clazz) {
+    JedisCommands cmd = cmd();
+    if (Objects.isNull(cmd)) {
+      return Optional.empty();
+    }
+
+    String encoded = cmd.hget(redisKey(key), validator);
+    if (Objects.isNull(encoded)) {
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("Cache get({}, {}) -> miss", key, validator);
+      }
+      return Optional.empty();
+    }
+
+    try {
+      T value = deserialize(Base64.getDecoder().decode(encoded), clazz);
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("Cache get({}, {}) -> hit ({})", key, validator, value);
+      }
+      return Optional.ofNullable(value);
+    } catch (IOException e) {
+      LOGGER.error("CACHE DESER", e);
+      return Optional.empty();
+    }
+  }
+
+  @Override
+  public void put(String key, Object value) {
+    write(key, CONTENT, value, 0);
+  }
+
+  @Override
+  public void put(String key, Object value, int ttl) {
+    write(key, CONTENT, value, ttl);
+  }
+
+  @Override
+  public void put(String key, String validator, Object value) {
+    write(key, validator, value, 0);
+  }
+
+  @Override
+  public void put(String key, String validator, Object value, int ttl) {
+    write(key, validator, value, ttl);
+  }
+
+  @Override
+  public void del(String key) {
+    JedisCommands cmd = cmd();
+    if (Objects.isNull(cmd)) {
+      return;
+    }
+
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Cache del({})", key);
+    }
+    cmd.del(redisKey(key));
+  }
+
+  private void write(String key, String validator, Object value, int ttl) {
+    JedisCommands cmd = cmd();
+    if (Objects.isNull(cmd)) {
+      return;
+    }
+
+    try {
+      String encoded = Base64.getEncoder().encodeToString(serialize(value));
+      String redisKey = redisKey(key);
+
+      cmd.hset(redisKey, validator, encoded);
+
+      if (ttl > 0) {
+        cmd.expire(redisKey, ttl);
+      } else {
+        cmd.persist(redisKey);
+      }
+
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("Cache put({}, {}, ttl={})", key, validator, ttl);
+      }
+    } catch (IOException e) {
+      // ignore, same as CacheDriverFs
+    }
+  }
+
+  private JedisCommands cmd() {
+    JedisCommands cmd = redis.cmd();
+    if (Objects.isNull(cmd) && LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Cache unavailable, redis is not connected yet");
+    }
+    return cmd;
+  }
+
+  private String redisKey(String key) {
+    return KEY_PREFIX + key;
+  }
+
+  private byte[] serialize(Object obj) throws IOException {
+    if (obj instanceof String) {
+      return ((String) obj).getBytes(StandardCharsets.UTF_8);
+    }
+
+    return valueEncoding.serialize(obj, FORMAT.SMILE);
+  }
+
+  private <T> T deserialize(byte[] value, Class<T> clazz) throws IOException {
+    if (String.class.equals(clazz)) {
+      return clazz.cast(new String(value, StandardCharsets.UTF_8));
+    }
+
+    return valueEncoding.getMapper(FORMAT.SMILE).readValue(value, clazz);
+  }
+}

--- a/xtraplatform-redis/src/main/java/de/ii/xtraplatform/redis/app/CacheDriverRedis.java
+++ b/xtraplatform-redis/src/main/java/de/ii/xtraplatform/redis/app/CacheDriverRedis.java
@@ -18,12 +18,11 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.Objects;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import redis.clients.jedis.commands.JedisCommands;
+import redis.clients.jedis.commands.JedisBinaryCommands;
 
 /**
  * Redis-backed CacheDriver, sharing the same Redis connection as JobQueueBackendRedis (s. Redis,
@@ -46,15 +45,15 @@ import redis.clients.jedis.commands.JedisCommands;
  * </ul>
  *
  * <p>Values are serialized identically to CacheDriverFs (String passthrough as UTF-8, everything
- * else via Jackson SMILE) and then Base64-encoded, since the Jedis command surface used here
- * (JedisCommands, via Redis.cmd()) is String-only, not binary-safe.
+ * else via Jackson SMILE) and stored as raw bytes via Redis.binary() (JedisBinaryCommands), which
+ * is binary-safe - no Base64 detour needed.
  *
- * <p>Redis.cmd() can legitimately return null - RedisImpl only actually connects lazily from its
+ * <p>Redis.binary() can legitimately return null - RedisImpl only actually connects lazily from its
  * periodic Volatile2 health check (s. RedisImpl's check()/connect()), not synchronously at startup,
  * so there's a window (and, if the connection is ever lost, an ongoing possibility) where no client
  * is available yet. Every method here treats that the same as a cache miss/no-op rather than
- * throwing, instead of assuming cmd() is always ready like CacheDriverFs's filesystem access always
- * is.
+ * throwing, instead of assuming binary() is always ready like CacheDriverFs's filesystem access
+ * always is.
  */
 @Singleton
 @AutoBind
@@ -94,12 +93,12 @@ public class CacheDriverRedis implements CacheDriver {
 
   @Override
   public boolean has(String key, String validator) {
-    JedisCommands cmd = cmd();
+    JedisBinaryCommands cmd = cmd();
     if (Objects.isNull(cmd)) {
       return false;
     }
 
-    boolean exists = cmd.hexists(redisKey(key), validator);
+    boolean exists = cmd.hexists(redisKey(key), validatorField(validator));
     if (LOGGER.isDebugEnabled()) {
       LOGGER.debug("Cache has({}, {}) -> {}", key, validator, exists);
     }
@@ -113,13 +112,13 @@ public class CacheDriverRedis implements CacheDriver {
 
   @Override
   public <T> Optional<T> get(String key, String validator, Class<T> clazz) {
-    JedisCommands cmd = cmd();
+    JedisBinaryCommands cmd = cmd();
     if (Objects.isNull(cmd)) {
       return Optional.empty();
     }
 
-    String encoded = cmd.hget(redisKey(key), validator);
-    if (Objects.isNull(encoded)) {
+    byte[] value = cmd.hget(redisKey(key), validatorField(validator));
+    if (Objects.isNull(value)) {
       if (LOGGER.isDebugEnabled()) {
         LOGGER.debug("Cache get({}, {}) -> miss", key, validator);
       }
@@ -127,11 +126,11 @@ public class CacheDriverRedis implements CacheDriver {
     }
 
     try {
-      T value = deserialize(Base64.getDecoder().decode(encoded), clazz);
+      T deserialized = deserialize(value, clazz);
       if (LOGGER.isDebugEnabled()) {
-        LOGGER.debug("Cache get({}, {}) -> hit ({})", key, validator, value);
+        LOGGER.debug("Cache get({}, {}) -> hit ({})", key, validator, deserialized);
       }
-      return Optional.ofNullable(value);
+      return Optional.ofNullable(deserialized);
     } catch (IOException e) {
       LOGGER.error("CACHE DESER", e);
       return Optional.empty();
@@ -160,7 +159,7 @@ public class CacheDriverRedis implements CacheDriver {
 
   @Override
   public void del(String key) {
-    JedisCommands cmd = cmd();
+    JedisBinaryCommands cmd = cmd();
     if (Objects.isNull(cmd)) {
       return;
     }
@@ -172,16 +171,16 @@ public class CacheDriverRedis implements CacheDriver {
   }
 
   private void write(String key, String validator, Object value, int ttl) {
-    JedisCommands cmd = cmd();
+    JedisBinaryCommands cmd = cmd();
     if (Objects.isNull(cmd)) {
       return;
     }
 
     try {
-      String encoded = Base64.getEncoder().encodeToString(serialize(value));
-      String redisKey = redisKey(key);
+      byte[] serialized = serialize(value);
+      byte[] redisKey = redisKey(key);
 
-      cmd.hset(redisKey, validator, encoded);
+      cmd.hset(redisKey, validatorField(validator), serialized);
 
       if (ttl > 0) {
         cmd.expire(redisKey, ttl);
@@ -197,16 +196,20 @@ public class CacheDriverRedis implements CacheDriver {
     }
   }
 
-  private JedisCommands cmd() {
-    JedisCommands cmd = redis.cmd();
+  private JedisBinaryCommands cmd() {
+    JedisBinaryCommands cmd = redis.binary();
     if (Objects.isNull(cmd) && LOGGER.isDebugEnabled()) {
       LOGGER.debug("Cache unavailable, redis is not connected yet");
     }
     return cmd;
   }
 
-  private String redisKey(String key) {
-    return KEY_PREFIX + key;
+  private byte[] redisKey(String key) {
+    return (KEY_PREFIX + key).getBytes(StandardCharsets.UTF_8);
+  }
+
+  private byte[] validatorField(String validator) {
+    return validator.getBytes(StandardCharsets.UTF_8);
   }
 
   private byte[] serialize(Object obj) throws IOException {

--- a/xtraplatform-redis/src/main/java/de/ii/xtraplatform/redis/app/RedisImpl.java
+++ b/xtraplatform-redis/src/main/java/de/ii/xtraplatform/redis/app/RedisImpl.java
@@ -32,6 +32,7 @@ import redis.clients.jedis.JedisPubSub;
 import redis.clients.jedis.RedisClient;
 import redis.clients.jedis.RedisClusterClient;
 import redis.clients.jedis.UnifiedJedis;
+import redis.clients.jedis.commands.JedisBinaryCommands;
 import redis.clients.jedis.commands.JedisCommands;
 import redis.clients.jedis.json.commands.RedisJsonCommands;
 
@@ -108,6 +109,11 @@ public class RedisImpl extends AbstractVolatilePolling implements Redis, AppLife
 
   @Override
   public JedisCommands cmd() {
+    return jedis;
+  }
+
+  @Override
+  public JedisBinaryCommands binary() {
     return jedis;
   }
 

--- a/xtraplatform-redis/src/main/java/de/ii/xtraplatform/redis/domain/Redis.java
+++ b/xtraplatform-redis/src/main/java/de/ii/xtraplatform/redis/domain/Redis.java
@@ -8,12 +8,15 @@
 package de.ii.xtraplatform.redis.domain;
 
 import de.ii.xtraplatform.base.domain.resiliency.Volatile2;
+import redis.clients.jedis.commands.JedisBinaryCommands;
 import redis.clients.jedis.commands.JedisCommands;
 import redis.clients.jedis.json.commands.RedisJsonCommands;
 
 public interface Redis extends Volatile2 {
 
   JedisCommands cmd();
+
+  JedisBinaryCommands binary();
 
   RedisJsonCommands json();
 


### PR DESCRIPTION
Adds CacheDriverRedis, a Redis-backed implementation of the existing CacheDriver interface, mirroring CacheDriverFs's key/validator layout but storing values as raw bytes via the new Redis.binary() accessor instead of Base64-encoded strings. CacheImpl now automatically selects this driver whenever redis.nodes is configured, and falls back to the file-based cache otherwise — no manual switch required. This lets multiple ldproxy instances share cached computations (e.g. feature counts, spatial/temporal extents) through a common Redis instance for horizontal scaling, verified end-to-end against a running Redis container.