### PR TITLE
entities: store diagnostics for defaults resolution and ignored files

### DIFF
--- a/xtraplatform-entities/src/main/java/de/ii/xtraplatform/entities/app/EntityDataDefaultsStoreImpl.java
+++ b/xtraplatform-entities/src/main/java/de/ii/xtraplatform/entities/app/EntityDataDefaultsStoreImpl.java
@@ -222,7 +222,9 @@ public class EntityDataDefaultsStoreImpl extends AbstractMergeableKeyValueStore<
 
     List<Identifier> cacheKeys = getCacheKeys(defaultsPath, subTypes);
 
-    // LOGGER.debug("Applying to subtypes as well 2: {} ### {}", event.identifier(), cacheKeys);
+    if (LOGGER.isTraceEnabled()) {
+      LOGGER.trace("DEFAULTS event {} -> cache keys {}", event.identifier(), cacheKeys);
+    }
 
     return cacheKeys.stream()
         .map(
@@ -355,6 +357,12 @@ public class EntityDataDefaultsStoreImpl extends AbstractMergeableKeyValueStore<
 
   private Map<String, Object> getDefaults(Identifier identifier) {
     if (eventSourcing.has(identifier)) {
+      if (LOGGER.isTraceEnabled()) {
+        LOGGER.trace(
+            "DEFAULTS lookup {} -> exact hit, keys {}",
+            identifier,
+            eventSourcing.get(identifier).keySet());
+      }
       return eventSourcing.get(identifier);
     }
 
@@ -365,6 +373,13 @@ public class EntityDataDefaultsStoreImpl extends AbstractMergeableKeyValueStore<
               .path(identifier.path().subList(i, identifier.path().size()))
               .build();
       if (eventSourcing.has(parent)) {
+        if (LOGGER.isTraceEnabled()) {
+          LOGGER.trace(
+              "DEFAULTS lookup {} -> parent hit {}, keys {}",
+              identifier,
+              parent,
+              eventSourcing.get(parent).keySet());
+        }
         try {
 
           return valueEncodingMap.deserialize(
@@ -378,6 +393,9 @@ public class EntityDataDefaultsStoreImpl extends AbstractMergeableKeyValueStore<
       }
     }
 
+    if (LOGGER.isTraceEnabled()) {
+      LOGGER.trace("DEFAULTS lookup {} -> no defaults found", identifier);
+    }
     return new LinkedHashMap<>();
   }
 

--- a/xtraplatform-entities/src/main/java/de/ii/xtraplatform/entities/app/EntityDataStoreImpl.java
+++ b/xtraplatform-entities/src/main/java/de/ii/xtraplatform/entities/app/EntityDataStoreImpl.java
@@ -336,6 +336,9 @@ public class EntityDataStoreImpl extends AbstractMergeableKeyValueStore<EntityDa
     Identifier defaultsIdentifier = EntityDataStore.defaults(identifier, entitySubtype);
 
     if (defaultsStore.has(defaultsIdentifier)) {
+      if (LOGGER.isTraceEnabled()) {
+        LOGGER.trace("ENTITY {} defaults builder: exact {}", identifier, defaultsIdentifier);
+      }
       return defaultsStore.getBuilder(defaultsIdentifier);
     }
 
@@ -343,8 +346,14 @@ public class EntityDataStoreImpl extends AbstractMergeableKeyValueStore<EntityDa
       Identifier parent = parent(defaultsIdentifier, i);
 
       if (defaultsStore.has(parent)) {
+        if (LOGGER.isTraceEnabled()) {
+          LOGGER.trace("ENTITY {} defaults builder: parent {}", identifier, parent);
+        }
         return defaultsStore.getBuilder(parent);
       }
+    }
+    if (LOGGER.isTraceEnabled()) {
+      LOGGER.trace("ENTITY {} defaults builder: none, using data builder", identifier);
     }
 
     return (EntityDataBuilder<EntityData>)

--- a/xtraplatform-entities/src/main/java/de/ii/xtraplatform/entities/domain/EventSource.java
+++ b/xtraplatform-entities/src/main/java/de/ii/xtraplatform/entities/domain/EventSource.java
@@ -124,6 +124,7 @@ public class EventSource {
     Matcher pathMatcher = pathPattern.matcher(fullRelPath.toString());
 
     if (!pathMatcher.find()) {
+      warnIgnoredFile(fullRelPath);
       return null;
     }
 
@@ -137,6 +138,7 @@ public class EventSource {
     }
 
     if (Objects.isNull(eventType) || Objects.isNull(eventId)) {
+      warnIgnoredFile(fullRelPath);
       return null;
     }
 
@@ -166,6 +168,18 @@ public class EventSource {
         .format(eventPayloadFormat.orElse(null))
         .source(source.getLabel())
         .build();
+  }
+
+  // A file that matches no path pattern is not an event and was previously
+  // dropped without any hint, which makes layout mistakes hard to spot.
+  private void warnIgnoredFile(Path fullRelPath) {
+    if (LOGGER.isWarnEnabled() && !fullRelPath.getFileName().toString().startsWith(".")) {
+      LOGGER.warn(
+          "Ignoring file in store source {}: '{}' does not match the expected layout '{}'",
+          source.getLabel(),
+          fullRelPath,
+          KEY_PATTERN);
+    }
   }
 
   private Path applyPrefixes(Path path) {


### PR DESCRIPTION
- trace logging for defaults events (cache keys), defaults lookups (exact/parent/none) and the defaults builder chosen per entity
- warn when a file in a store source matches no path pattern instead of dropping it silently (hidden files exempt); a mislaid defaults file like defaults/<type>.yml is otherwise invisible